### PR TITLE
Add Terms, Privacy, and Refund Policy legal pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -51,6 +51,14 @@
               "resources/faq",
               "resources/best-practices"
             ]
+          },
+          {
+            "group": "Legal",
+            "pages": [
+              "legal/terms",
+              "legal/privacy",
+              "legal/refund"
+            ]
           }
         ]
       },
@@ -123,6 +131,25 @@
   "footer": {
     "socials": {
       "github": "https://github.com/onetest-ai"
-    }
+    },
+    "links": [
+      {
+        "header": "Legal",
+        "links": [
+          {
+            "label": "Terms of Service",
+            "href": "/legal/terms"
+          },
+          {
+            "label": "Privacy Policy",
+            "href": "/legal/privacy"
+          },
+          {
+            "label": "Refund Policy",
+            "href": "/legal/refund"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/legal/privacy.mdx
+++ b/legal/privacy.mdx
@@ -1,0 +1,101 @@
+---
+title: Privacy Policy
+description: How OneTest collects, uses, and protects your data
+---
+
+**Effective Date:** January 1, 2025
+
+This Privacy Policy describes how OneTest AI ("we," "us," or "our") collects, uses, and shares information about you when you use the OneTest platform ("Service").
+
+By using the Service, you agree to the collection and use of information in accordance with this policy.
+
+## 1. Information We Collect
+
+### Information You Provide
+
+- **Account information:** Name, email address, and password when you create an account
+- **Profile information:** Organization name, job title, and other optional profile details
+- **User content:** Test cases, test runs, configurations, and other content you create within OneTest
+- **Payment information:** Billing details processed securely via our payment provider (we do not store raw card numbers)
+- **Communications:** Messages you send to our support team
+
+### Information Collected Automatically
+
+- **Usage data:** Pages visited, features used, and actions taken within the Service
+- **Log data:** IP address, browser type, operating system, and timestamps
+- **Cookies and similar technologies:** We use cookies to maintain sessions, remember preferences, and analyze usage
+
+### Information from Third Parties
+
+- **Authentication providers:** If you sign in via a third-party identity provider (e.g., Google, GitHub), we receive basic profile information
+- **Integrations:** When you connect third-party tools, we receive data necessary to enable that integration
+
+## 2. How We Use Your Information
+
+We use the information we collect to:
+
+- Provide, maintain, and improve the Service
+- Process transactions and send related communications
+- Send technical notices, updates, security alerts, and support messages
+- Respond to your comments and questions
+- Analyze usage patterns to improve user experience
+- Detect, investigate, and prevent fraudulent or unauthorized activity
+- Comply with legal obligations
+
+### AI Processing
+
+When you use AI features, your test data and prompts are processed by our AI infrastructure. We do not use your content to train third-party AI models without your explicit consent.
+
+## 3. How We Share Your Information
+
+We do not sell your personal information. We may share your information with:
+
+- **Service providers:** Third-party vendors who assist in operating our platform (hosting, analytics, payment processing, email delivery)
+- **Team members:** Other users in your organization who have been granted access to the same workspace
+- **Legal requirements:** When required by law, court order, or governmental authority
+- **Business transfers:** In connection with a merger, acquisition, or sale of assets, with appropriate confidentiality protections
+- **With your consent:** For any other purpose with your explicit consent
+
+## 4. Data Retention
+
+We retain your data for as long as your account is active or as needed to provide the Service. After account deletion, we may retain certain data for up to 90 days for backup and legal compliance purposes, after which it is permanently deleted.
+
+## 5. Data Security
+
+We implement industry-standard security measures including encryption in transit (TLS), encryption at rest, access controls, and regular security reviews. However, no method of transmission over the Internet is 100% secure.
+
+## 6. Your Rights
+
+Depending on your location, you may have the right to:
+
+- **Access:** Request a copy of the personal data we hold about you
+- **Correction:** Request correction of inaccurate or incomplete data
+- **Deletion:** Request deletion of your personal data
+- **Portability:** Receive your data in a machine-readable format
+- **Objection:** Object to certain types of processing
+- **Withdrawal of consent:** Withdraw consent at any time where processing is based on consent
+
+To exercise these rights, contact us at privacy@onetest.ai.
+
+## 7. Cookies
+
+We use essential cookies for session management and optional analytics cookies to understand how the Service is used. You can control cookie preferences through your browser settings.
+
+## 8. Children's Privacy
+
+The Service is not directed to children under 18. We do not knowingly collect personal information from children under 18. If you believe we have collected such information, please contact us immediately.
+
+## 9. International Data Transfers
+
+Your information may be transferred to and processed in countries other than your own. We ensure appropriate safeguards are in place for such transfers in accordance with applicable data protection laws.
+
+## 10. Changes to This Policy
+
+We may update this Privacy Policy from time to time. We will notify you of significant changes by email or through the Service. Your continued use of the Service after changes become effective constitutes acceptance of the revised policy.
+
+## 11. Contact Us
+
+If you have questions or concerns about this Privacy Policy, please contact us at:
+
+**Email:** privacy@onetest.ai  
+**Website:** [https://onetest.ai](https://onetest.ai)

--- a/legal/refund.mdx
+++ b/legal/refund.mdx
@@ -1,0 +1,82 @@
+---
+title: Refund Policy
+description: OneTest refund and cancellation policy
+---
+
+**Effective Date:** January 1, 2025
+
+This Refund Policy outlines the terms under which OneTest AI ("we," "us," or "our") provides refunds for subscriptions to the OneTest platform ("Service").
+
+## Overview
+
+We want you to be satisfied with OneTest. If you're not happy with your subscription, we offer a straightforward refund process as described below.
+
+## Free Trial
+
+New accounts are eligible for a **14-day free trial** with no credit card required. The trial gives you full access to evaluate the Service before committing to a paid plan. No charge is applied during the trial period.
+
+## Monthly Subscriptions
+
+For monthly subscription plans:
+
+- **Within 7 days of initial purchase:** You are eligible for a full refund if you have not exceeded 20% of your plan's usage limits (e.g., AI credits, test cases stored).
+- **After 7 days:** Refunds are not available for the current billing period. You may cancel your subscription at any time, and you will retain access to the Service until the end of the current billing period.
+
+## Annual Subscriptions
+
+For annual subscription plans:
+
+- **Within 30 days of initial purchase:** You are eligible for a full refund if you have not significantly utilized the Service (less than 20% of annual usage limits consumed).
+- **After 30 days:** We offer a **pro-rated refund** for the unused portion of your annual subscription, at our discretion, for exceptional circumstances (e.g., extended service outages caused by us, or inability to use the Service due to our error).
+- **No refund** is issued for annual subscriptions cancelled after 30 days under ordinary circumstances. You will retain access to the Service until the end of your annual term.
+
+## Plan Upgrades and Downgrades
+
+- **Upgrades:** When you upgrade to a higher plan, the price difference is billed immediately on a pro-rated basis. No refund is given for the unused portion of the lower-tier plan.
+- **Downgrades:** When you downgrade to a lower plan, the change takes effect at the start of your next billing period. No partial refunds are issued for the current period.
+
+## Exceptional Circumstances
+
+We may grant refunds outside of the above policy at our sole discretion in cases such as:
+
+- Significant service outages or data loss caused by us
+- Billing errors or duplicate charges
+- Fraudulent charges (subject to investigation)
+
+## How to Request a Refund
+
+To request a refund, contact our support team:
+
+**Email:** support@onetest.ai  
+**Subject line:** Refund Request — [your account email]
+
+Please include:
+
+1. Your account email address
+2. The subscription plan and billing date in question
+3. A brief explanation of why you are requesting a refund
+
+We aim to respond to all refund requests within **3 business days**. Approved refunds are processed within **5–10 business days** and returned to the original payment method.
+
+## Non-Refundable Items
+
+The following are not eligible for refunds:
+
+- Usage-based overage charges
+- Add-on purchases once consumed
+- Fees for custom enterprise agreements (governed by a separate contract)
+
+## Cancellation
+
+You can cancel your subscription at any time from the **Settings → Billing** page within OneTest. Cancellation stops future charges but does not entitle you to a refund for amounts already paid, except as described in this policy.
+
+## Changes to This Policy
+
+We reserve the right to update this Refund Policy at any time. Changes will be communicated via email or a notice within the Service. Your continued use of the Service after changes take effect constitutes acceptance of the revised policy.
+
+## Contact Us
+
+For billing or refund questions, contact us at:
+
+**Email:** support@onetest.ai  
+**Website:** [https://onetest.ai](https://onetest.ai)

--- a/legal/terms.mdx
+++ b/legal/terms.mdx
@@ -1,0 +1,80 @@
+---
+title: Terms of Service
+description: Terms and Conditions for using OneTest
+---
+
+**Effective Date:** January 1, 2025
+
+Please read these Terms of Service ("Terms") carefully before using the OneTest platform ("Service") operated by OneTest AI ("we," "us," or "our").
+
+By accessing or using the Service, you agree to be bound by these Terms. If you disagree with any part of these Terms, you may not access the Service.
+
+## 1. Accounts
+
+You must create an account to access OneTest. You are responsible for maintaining the confidentiality of your account credentials and for all activity that occurs under your account. You must immediately notify us of any unauthorized use of your account.
+
+You must be at least 18 years old to use the Service. By using the Service, you represent that you meet this requirement.
+
+## 2. Subscription and Billing
+
+OneTest is offered on a subscription basis. You agree to pay all fees associated with your selected plan. Fees are billed in advance on a monthly or annual basis and are non-refundable except as described in our [Refund Policy](/legal/refund).
+
+We reserve the right to change our pricing with 30 days' notice. Continued use of the Service after a price change constitutes acceptance of the new pricing.
+
+## 3. Acceptable Use
+
+You agree not to use the Service to:
+
+- Violate any applicable laws or regulations
+- Upload or transmit malicious code or content
+- Attempt to gain unauthorized access to any part of the Service
+- Interfere with or disrupt the integrity or performance of the Service
+- Scrape, crawl, or systematically extract data from the Service without permission
+- Resell or sublicense access to the Service without our express written consent
+
+## 4. Intellectual Property
+
+The Service and its original content, features, and functionality are and will remain the exclusive property of OneTest AI. Our trademarks and trade dress may not be used without our prior written consent.
+
+Content you upload or create within OneTest ("User Content") remains your property. By uploading User Content, you grant us a limited license to store, process, and display it solely to provide the Service.
+
+## 5. AI Features
+
+OneTest uses artificial intelligence to assist with test generation and analysis. AI-generated content is provided as-is and should be reviewed before use. We do not warrant the accuracy, completeness, or fitness for purpose of AI-generated output.
+
+Your use of AI features is subject to the usage limits defined in your subscription plan.
+
+## 6. Data and Privacy
+
+Your use of the Service is also governed by our [Privacy Policy](/legal/privacy), which is incorporated into these Terms by reference.
+
+## 7. Limitation of Liability
+
+To the maximum extent permitted by applicable law, OneTest AI shall not be liable for any indirect, incidental, special, consequential, or punitive damages, including loss of profits, data, or goodwill, arising from your use of or inability to use the Service.
+
+Our total liability to you for any claims arising from these Terms or your use of the Service shall not exceed the amount you paid to us in the 12 months preceding the claim.
+
+## 8. Disclaimer of Warranties
+
+The Service is provided "as is" and "as available" without warranties of any kind, either express or implied, including but not limited to implied warranties of merchantability, fitness for a particular purpose, or non-infringement.
+
+## 9. Termination
+
+We may terminate or suspend your account and access to the Service at our sole discretion, without prior notice, for conduct that we believe violates these Terms or is harmful to other users, us, or third parties.
+
+You may terminate your account at any time by contacting us. Upon termination, your right to use the Service immediately ceases.
+
+## 10. Changes to Terms
+
+We reserve the right to modify these Terms at any time. We will provide notice of significant changes via email or a prominent notice on the Service. Your continued use of the Service after such changes constitutes acceptance of the revised Terms.
+
+## 11. Governing Law
+
+These Terms shall be governed by and construed in accordance with applicable law, without regard to its conflict of law provisions.
+
+## 12. Contact Us
+
+If you have questions about these Terms, please contact us at:
+
+**Email:** legal@onetest.ai  
+**Website:** [https://onetest.ai](https://onetest.ai)


### PR DESCRIPTION
## Summary

Adds the three legal pages required for payment processor compliance, with footer links.

### Changes
- **`legal/terms.mdx`** — Terms of Service
- **`legal/privacy.mdx`** — Privacy Policy  
- **`legal/refund.mdx`** — Refund Policy (14-day trial, 7-day monthly refund window, 30-day annual refund window)
- **`docs.json`** — Added `Legal` navigation group + footer `links` array pointing to all three pages

### Footer
The footer now includes a "Legal" section with links visible on every page of the docs site.