### PR TITLE
fix(docs): add hidden Legal navigation group to fix /legal/* 404s

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -45,11 +45,20 @@
               "settings/mcp-servers"
             ]
           },
-{
+          {
             "group": "Resources",
             "pages": [
               "resources/faq",
               "resources/best-practices"
+            ]
+          },
+          {
+            "group": "Legal",
+            "hidden": true,
+            "pages": [
+              "legal/terms",
+              "legal/privacy",
+              "legal/refund"
             ]
           }
         ]


### PR DESCRIPTION
## Problem

Footer links to **Terms of Service**, **Privacy Policy**, and **Refund Policy** all 404 — the `.mdx` files exist and the footer `href`s are configured, but Mintlify only publishes pages that are listed in the `navigation` structure in `docs.json`.

## Fix

Added a `"hidden": true` group under the Documentation tab:

```json
{
  "group": "Legal",
  "hidden": true,
  "pages": ["legal/terms", "legal/privacy", "legal/refund"]
}
```

- Pages are now published and accessible via direct URL (`/legal/terms`, etc.)
- The `hidden: true` flag keeps them out of the sidebar navigation
- Footer links continue to work as configured