### PR TITLE
fix(docs): change support email to artem@onetest.ai

### DIFF
--- a/getting-started/quickstart.mdx
+++ b/getting-started/quickstart.mdx
@@ -361,7 +361,7 @@ Congratulations! You've created and run your first test. Now you can:
     Found a bug? Let us know
   </Card>
 
-  <Card title="Email Support" icon="envelope" href="mailto:support@onetest.ai">
+  <Card title="Email Support" icon="envelope" href="mailto:artem@onetest.ai">
     Get help from our team
   </Card>
 </CardGroup>

--- a/getting-started/your-first-test.mdx
+++ b/getting-started/your-first-test.mdx
@@ -218,7 +218,7 @@ Having trouble? Try these:
     Video tutorial on creating tests
   </Card>
 
-  <Card title="Get Support" icon="envelope" href="mailto:support@onetest.ai">
+  <Card title="Get Support" icon="envelope" href="mailto:artem@onetest.ai">
     Email our support team
   </Card>
 </CardGroup>

--- a/legal/refund.mdx
+++ b/legal/refund.mdx
@@ -47,7 +47,7 @@ We may grant refunds outside of the above policy at our sole discretion in cases
 
 To request a refund, contact our support team:
 
-**Email:** support@onetest.ai  
+**Email:** artem@onetest.ai  
 **Subject line:** Refund Request — [your account email]
 
 Please include:
@@ -78,5 +78,5 @@ We reserve the right to update this Refund Policy at any time. Changes will be c
 
 For billing or refund questions, contact us at:
 
-**Email:** support@onetest.ai  
+**Email:** artem@onetest.ai  
 **Website:** [https://onetest.ai](https://onetest.ai)

--- a/resources/faq.mdx
+++ b/resources/faq.mdx
@@ -369,9 +369,9 @@ icon: circle-question
   <Card
     title="Email Support"
     icon="envelope"
-    href="mailto:support@onetest.ai"
+    href="mailto:artem@onetest.ai"
   >
-    support@onetest.ai
+    artem@onetest.ai
   </Card>
 
   <Card
@@ -404,7 +404,7 @@ icon: circle-question
 <Card
   title="Contact Support"
   icon="headset"
-  href="mailto:support@onetest.ai"
+  href="mailto:artem@onetest.ai"
 >
-  Our team is here to help! Email us at support@onetest.ai
+  Our team is here to help! Email us at artem@onetest.ai
 </Card>


### PR DESCRIPTION
Replaces `support@onetest.ai` → `artem@onetest.ai` across all docs pages.

**Files updated (8 occurrences):**
- `legal/refund.mdx` (2x)
- `resources/faq.mdx` (4x)
- `getting-started/quickstart.mdx` (1x)
- `getting-started/your-first-test.mdx` (1x)